### PR TITLE
Add instructions for validating success to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Example:
 docker run --rm georift/install-jellyfin-tizen 192.168.0.10 Jellyfin-TrueHD "https://github.com/jeppevinkel/jellyfin-tizen-builds/releases/tag/2024-05-13-0139"
 ```
 
+### Validating Success
+
+If everything went well, you should see docker output something like the following
+
+```txt
+Installed the package: Id(AprZAARz4r.Jellyfin)
+Tizen application is successfully installed.
+Total time: 00:00:12.205
+```
+
+At this point you can find jellyfin on your TV by navigating to apps -> downloaded (scroll down), where you'll find jellyfin.
+
 ## Supported platforms
 
 At the moment, these steps should work on any amd64 based system. Platforms


### PR DESCRIPTION
This is a very minor change that adds instructions for validating success to the `README`.

The reason for adding these instructions is that I spent the better part of an hour trying to figure out why docker said success, but the app didn't show up on my home screen 🤦‍♂️

Guessing if I'm dumb enough to make that mistake, others may also benefit from some validation instructions.