### PR TITLE
feat: added option to sign wgt using custom certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM vitalets/tizen-webos-sdk
 
-COPY entrypoint.sh . 
+COPY entrypoint.sh profile.xml ./
 
 # jq for quickly parsing the TV name from the API endpoint
 RUN apt update && apt install jq -y && rm -rf /var/lib/apt/lists/* && rm -rf /var/cache/apt/*

--- a/README.md
+++ b/README.md
@@ -31,16 +31,22 @@ For documentation about the Jellyfin app, see [here](https://github.com/jellyfin
 
    - (Optional) You can provide preferred [jellyfin-tizen-builds](https://github.com/jeppevinkel/jellyfin-tizen-builds) option (Jellyfin / Jellyfin-TrueHD / Jellyfin-master / Jellyfin-master-TrueHD / Jellyfin-secondary) as second argument. By default, Jellyfin option is used.
    - (Optional) You can provide preferred [jellyfin-tizen-builds releases](https://github.com/jeppevinkel/jellyfin-tizen-builds/releases) release tag URL as third argument. By default, latest version is used. This is useful if you want to install older Jellyfin Tizen Client version.
+   - (Optional) You can provide a custom Samsung certificate by mounting the `.p12` files at `/certificates/` and providing the certificate password as fourth argument.
    - If you do not want to use either of these options and just install the default build, do not put anything after the IP address.
 
 ```bash
-docker run --rm ghcr.io/georift/install-jellyfin-tizen <samsung tv ip> <build option> <tag url>
+docker run --rm ghcr.io/georift/install-jellyfin-tizen <samsung tv ip> <build option> <tag url> <certificate password>
 ```
 
-Example:
+Examples:
 
 ```bash
 docker run --rm ghcr.io/georift/install-jellyfin-tizen 192.168.0.10 Jellyfin-TrueHD "https://github.com/jeppevinkel/jellyfin-tizen-builds/releases/tag/2024-05-13-0139"
+```
+
+
+```bash
+docker run --rm -v "$(pwd)/author.p12":/certificates/author.p12 -v "$(pwd)/distributor.p12":/certificates/distributor.p12 ghcr.io/georift/install-jellyfin-tizen 192.168.0.10 Jellyfin "" 'CertPassw0rd!' # Third argument empty to use latest tag
 ```
 
 ### Validating Success
@@ -74,6 +80,12 @@ like the Raspberry Pi, which run ARM chips, are not yet supported, but
 - `install failed[118, -11], reason: Author certificate not match :`
 
   Uninstall the Jellyfin application from your Samsung TV, and run the installation again.
+
+- `install failed[118, -12], reason: Check certificate error : :Invalid certificate chain with certificate in signature.`
+
+  Recent TV models require the installation packages to be signed with a custom certificate for your specific TV.
+
+  See [official documentation](https://developer.samsung.com/smarttv/develop/getting-started/setting-up-sdk/creating-certificates.html) on creating your certificate and use the custom certificate arguments.
 
 ## Credits
 

--- a/profile.xml
+++ b/profile.xml
@@ -1,0 +1,5 @@
+<profile name="custom">
+<profileitem ca="" distributor="0" key="/certificates/author.p12" password="_CERTIFICATEPASSWORD_" rootca=""/>
+<profileitem ca="" distributor="1" key="/certificates/distributor.p12" password="_CERTIFICATEPASSWORD_" rootca=""/>
+<profileitem ca="" distributor="2" key="" password="" rootca=""/>
+</profile>


### PR DESCRIPTION
Related to #21 

Hi,

I made some changes to allow the use of a custom certificate by mounting the `.p12` files to `/certificates`, then modifying the `/home/developer/tizen-studio-data/profile/profiles.xml` file adding the custom profile and using a user provided password from an argument.

Let me know any improvements to be made to the code or documentation.